### PR TITLE
feat: add custom object and component prefixing

### DIFF
--- a/defaultConfig.js
+++ b/defaultConfig.js
@@ -1,4 +1,3 @@
-// This file is deprecated and due to be removed. Import '@captaincss/captaincss/defaultConfig` instead
 const cloneDeep = require('lodash/cloneDeep');
 const defaultConfig = require('./stubs/defaultConfig.stub.js');
 

--- a/src/components/skip-link.js
+++ b/src/components/skip-link.js
@@ -6,14 +6,14 @@
 
 const { pluginDisabled } = require('../utilities');
 
-module.exports = function ({ addComponents, config, theme, variants }) {
+module.exports = function ({ addComponents, config, theme, variants, prefixComponent }) {
   if (pluginDisabled('skipLink', config)) return;
 
   const userStyles = theme('skipLink.styles');
 
   const skipLink = [
     {
-      '.skip-link': Object.assign(
+      [prefixComponent('.skip-link')]: Object.assign(
         {
           clip: 'rect(1px, 1px, 1px, 1px)',
           display: 'block',
@@ -30,7 +30,7 @@ module.exports = function ({ addComponents, config, theme, variants }) {
         userStyles
       ),
 
-      '.skip-link:focus': {
+      [prefixComponent('.skip-link:focus')]: {
         clip: 'auto',
         height: 'auto',
         overflow: 'visible',
@@ -39,5 +39,8 @@ module.exports = function ({ addComponents, config, theme, variants }) {
     },
   ];
 
-  return addComponents(skipLink, variants('skipLink'));
+  return addComponents(skipLink, {
+    respectPrefix: false,
+    variants: variants('skipLink'),
+  });
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,18 +1,29 @@
 const plugin = require('tailwindcss/plugin');
-const defaultConfig = require('./defaultConfig');
+const defaultConfig = require('../stubs/defaultConfig.stub');
+
+const createPrefixer = require('./util/prefixSelector');
 
 const addClusterComponent = require('./objects/cluster');
 const addFrameComponent = require('./objects/frame');
 const addStackComponent = require('./objects/stack');
 const addWrapperComponent = require('./objects/wrapper');
 
-const addSkipLinkComponent = require('./objects/skip-link');
+const addSkipLinkComponent = require('./components/skip-link');
 
 const addActiveBreakpointUtility = require('./utilities/active-breakpoint');
 const addIntrinsicCenterUtility = require('./utilities/intrinsic-center');
 const addDebugUtility = require('./utilities/debug');
 
 module.exports = plugin(function (params) {
+  params.prefixObject = createPrefixer(
+    params.config('captain.prefix.objects'),
+    params.config('prefix')
+  );
+  params.prefixComponent = createPrefixer(
+    params.config('captain.prefix.components'),
+    params.config('prefix')
+  );
+
   addClusterComponent(params);
   addFrameComponent(params);
   addStackComponent(params);

--- a/src/objects/cluster.js
+++ b/src/objects/cluster.js
@@ -13,7 +13,7 @@
 const _ = require('lodash');
 const { pluginDisabled } = require('../utilities');
 
-module.exports = function ({ addComponents, config, theme, variants, e }) {
+module.exports = function ({ addComponents, config, theme, variants, e, prefixObject }) {
   if (pluginDisabled('cluster', config)) return;
 
   let gap = theme('cluster.gap');
@@ -23,7 +23,7 @@ module.exports = function ({ addComponents, config, theme, variants, e }) {
 
   const cluster = [
     {
-      '.cluster': {
+      [prefixObject('.cluster')]: {
         overflow: 'hidden',
 
         '> *': {
@@ -45,7 +45,7 @@ module.exports = function ({ addComponents, config, theme, variants, e }) {
     const mod = modifier === 'DEFAULT' ? '' : `--${modifier}`;
 
     const style = {
-      [`.${e(`cluster${mod}`)}`]: {
+      [prefixObject(`.${e(`cluster${mod}`)}`)]: {
         '--cluster-space': spacingValue,
       },
     };
@@ -58,5 +58,8 @@ module.exports = function ({ addComponents, config, theme, variants, e }) {
     }
   }
 
-  return addComponents(cluster, variants('cluster'));
+  return addComponents(cluster, {
+    respectPrefix: false,
+    variants: variants('cluster'),
+  });
 };

--- a/src/objects/frame.js
+++ b/src/objects/frame.js
@@ -11,14 +11,14 @@
 
 const { pluginDisabled } = require('../utilities');
 
-module.exports = function ({ addComponents, config, theme, variants, e }) {
+module.exports = function ({ addComponents, config, theme, variants, e, prefixObject }) {
   if (pluginDisabled('frame', config)) return;
 
   const ratios = theme('frame.ratios');
 
   const frame = [
     {
-      '.frame': {
+      [prefixObject('.frame')]: {
         '--frame-antecedent': 9,
         '--frame-consequent': 16,
         paddingBottom: 'calc(var(--frame-consequent) / var(--frame-antecedent) * 100%)',
@@ -48,12 +48,15 @@ module.exports = function ({ addComponents, config, theme, variants, e }) {
   for (const [ratioName, ratioPair] of Object.entries(ratios)) {
     const [antecedent, consequent] = ratioPair.split(':');
     frame.push({
-      [`.${e(`frame--${ratioName}`)}`]: {
+      [prefixObject(`.${e(`frame--${ratioName}`)}`)]: {
         '--frame-antecedent': antecedent,
         '--frame-consequent': consequent,
       },
     });
   }
 
-  return addComponents(frame, variants('frame'));
+  return addComponents(frame, {
+    respectPrefix: false,
+    variants: variants('frame'),
+  });
 };

--- a/src/objects/stack.js
+++ b/src/objects/stack.js
@@ -29,7 +29,7 @@
 const _ = require('lodash');
 const { pluginDisabled } = require('../utilities');
 
-module.exports = function ({ addComponents, config, theme, variants, e }) {
+module.exports = function ({ addComponents, config, theme, variants, e, prefixObject }) {
   if (pluginDisabled('stack', config)) return;
 
   let gap = theme('stack.gap');
@@ -39,7 +39,7 @@ module.exports = function ({ addComponents, config, theme, variants, e }) {
 
   const stack = [
     {
-      '.stack': {
+      [prefixObject('.stack')]: {
         '--stack-reverse': '0',
         display: 'flex',
         flexDirection: 'column',
@@ -67,7 +67,7 @@ module.exports = function ({ addComponents, config, theme, variants, e }) {
     const mod = modifier === 'DEFAULT' ? '' : `--${modifier}`;
 
     const style = {
-      [`.${e(`stack${mod}`)}`]: {
+      [prefixObject(`.${e(`stack${mod}`)}`)]: {
         '--stack-space': spacingValue,
       },
     };
@@ -80,5 +80,8 @@ module.exports = function ({ addComponents, config, theme, variants, e }) {
     }
   }
 
-  return addComponents(stack, variants('stack'));
+  return addComponents(stack, {
+    respectPrefix: false,
+    variants: variants('stack'),
+  });
 };

--- a/src/objects/wrapper.js
+++ b/src/objects/wrapper.js
@@ -15,7 +15,7 @@
 const _ = require('lodash');
 const { extractMinWidths, mapMinWidthsToValues, pluginDisabled } = require('../utilities');
 
-module.exports = function ({ addComponents, config, theme, variants, e }) {
+module.exports = function ({ addComponents, config, theme, variants, e, prefixObject }) {
   if (pluginDisabled('wrapper', config)) return;
 
   const screens = theme('wrapper.screens', theme('screens'));
@@ -59,7 +59,7 @@ module.exports = function ({ addComponents, config, theme, variants, e }) {
 
       return {
         [`@media (min-width: ${minWidth})`]: {
-          '.wrapper': {
+          [prefixObject('.wrapper')]: {
             ...paddingStyles,
           },
         },
@@ -69,7 +69,7 @@ module.exports = function ({ addComponents, config, theme, variants, e }) {
 
   const wrapper = [
     {
-      '.wrapper': {
+      [prefixObject('.wrapper')]: {
         boxSizing: 'border-box',
         display: 'block',
         marginLeft: 'auto',
@@ -98,7 +98,7 @@ module.exports = function ({ addComponents, config, theme, variants, e }) {
     const mod = modifier === 'DEFAULT' ? '' : `--${modifier}`;
 
     const style = {
-      [`.${e(`wrapper${mod}`)}`]: {
+      [prefixObject(`.${e(`wrapper${mod}`)}`)]: {
         maxWidth: widthValue,
       },
     };
@@ -110,5 +110,8 @@ module.exports = function ({ addComponents, config, theme, variants, e }) {
     }
   }
 
-  return addComponents(wrapper, variants('wrapper'));
+  return addComponents(wrapper, {
+    respectPrefix: false,
+    variants: variants('wrapper'),
+  });
 };

--- a/src/util/prefixSelector.js
+++ b/src/util/prefixSelector.js
@@ -1,0 +1,9 @@
+const prefixSelector = require('tailwindcss/lib/util/prefixSelector').default;
+
+module.exports = function createPrefixer(prefix, fallbackPrefix) {
+  if (!prefix) prefix = fallbackPrefix;
+
+  return function (selector) {
+    return prefixSelector(prefix, selector);
+  };
+};

--- a/stubs/defaultConfig.stub.js
+++ b/stubs/defaultConfig.stub.js
@@ -1,0 +1,63 @@
+module.exports = {
+  captain: {
+    prefix: {
+      components: 'c-', // Falsey value will default to config.prefix instead
+      objects: 'o-',
+    }
+  },
+  theme: {
+    activeBreakpoint: (theme) => ({
+      screens: theme('screens'),
+      position: ['top', 'right'],
+      prefix: '',
+      suffix: '',
+      ignoreScreens: ['dark'],
+      styles: {},
+      selector: 'body',
+      pseudo: 'before',
+    }),
+    cluster: (theme) => ({
+      gap: {
+        DEFAULT: '1rem',
+        ...theme('space'),
+      },
+    }),
+    debug: {
+      accessibility: false,
+    },
+    frame: {
+      ratios: {
+        '1:1': '1:1',
+        '16:9': '16:9',
+        golden: '1.618:1',
+      },
+    },
+    stack: (theme) => ({
+      gap: {
+        DEFAULT: '1rem',
+        ...theme('space'),
+      },
+    }),
+    skipLink: {
+      styles: {},
+    },
+    wrapper: {
+      padding: {
+        DEFAULT: '1rem',
+        md: '2rem',
+        lg: '3.5rem',
+        xl: '5rem',
+      },
+      maxWidth: {
+        DEFAULT: '80rem',
+        sm: '60rem',
+        lg: '90rem',
+      },
+    },
+  },
+  variants: {
+    cluster: ['responsive'],
+    frame: ['responsive'],
+    stack: ['responsive'],
+  },
+};


### PR DESCRIPTION
ITCSS defines components prefixed as c-, and objects prefixed as o-.

This commit creates that functionality.

To specify a component or object prefix, use the `config.captain.prefix` object:

```js
module.exports = {
  captain: {
    prefix: {
      components: 'c-',
      objects: 'o-',
    }
  },
};
```

To leave one or both as the specified Tailwind prefix, just give a falsey value:

```js
module.exports = {
  captain: {
    prefix: {
      components: null, // Will default to config('prefix')
      objects: '', // Will also default to config('prefix')
    }
  },
};
```

This PR also moves skip-link to the components directory now that there
is an actual distinction.

## Creating the Prefixers

I was unable to get the object and component prefixers into the parameters that Tailwind gives the `plugin` method.

This meant I had to inject them myself at the start of the plugin.

If any users wish to create their own plugins with objects or components, they will also need to manually inject them. They can do this by importing the `createPrefixer` method from '@captancss/captaincss/src/util/prefixSelector', and using it like so:

```js
module.exports = plugin(function (params) {
  params.prefixObject = createPrefixer(
    params.config('captain.prefix.objects'),
    params.config('prefix')
  );
  params.prefixComponent = createPrefixer(
    params.config('captain.prefix.components'),
    params.config('prefix')
  );

   ...
};
```